### PR TITLE
[Feat] 좋아요 API 구현 및 전체 도서 / 상세 도서 조회에 좋아요 기능 추가

### DIFF
--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -23,7 +23,24 @@ const addLike = (req, res) => {
 };
 
 const removeLike = (req, res) => {
-    res.json({ message: "좋아요 취소" })
+    const { id } = req.params;
+    const { user_id } = req.body;
+
+    let sql = "DELETE FROM likes WHERE user_id = ? AND liked_book_id = ?";
+
+    conn.query(sql, [user_id, parseInt(id)], (err, results) => {
+        if (err) {
+            return res.status(StatusCodes.BAD_REQUEST).json({
+                message: err
+            })
+        }
+
+        if (results.affectedRows === 0) {
+            return res.status(StatusCodes.BAD_REQUEST).end();
+        } else {
+            return res.status(StatusCodes.OK).json(results);
+        }
+    })
 };
 
 module.exports = { addLike, removeLike }

--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -2,7 +2,24 @@ const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 
 const addLike = (req, res) => {
-    res.json({ message: "좋아요 추가" })
+    const { id } = req.params;
+    const { user_id } = req.body;
+
+    let sql = "INSERT INTO likes (user_id, liked_book_id) VALUES (?, ?)";
+
+    conn.query(sql, [user_id, parseInt(id)], (err, results) => {
+        if (err) {
+            return res.status(StatusCodes.BAD_REQUEST).json({
+                message: err
+            })
+        }
+
+        if (results.affectedRows === 0) {
+            return res.status(StatusCodes.BAD_REQUEST).end();
+        } else {
+            return res.status(StatusCodes.OK).json(results);
+        }
+    })
 };
 
 const removeLike = (req, res) => {

--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -1,0 +1,12 @@
+const conn = require("../db/mariadb");
+const { StatusCodes } = require("http-status-codes");
+
+const addLike = (req, res) => {
+    res.json({ message: "좋아요 추가" })
+};
+
+const removeLike = (req, res) => {
+    res.json({ message: "좋아요 취소" })
+};
+
+module.exports = { addLike, removeLike }

--- a/routes/likes.js
+++ b/routes/likes.js
@@ -1,14 +1,11 @@
 const express = require("express");
+const { addLike, removeLike } = require("../controller/likeController");
 const router = express.Router();
 
 router.use(express.json);
 
-router.put("/:id", (req, res) => {
-    res.json({ message: "좋아요 추가" })
-});
+router.put("/:id", addLike);
 
-router.put("/:id", (req, res) => {
-    res.json({ message: "좋아요 취소" })
-});
+router.put("/:id", removeLike);
 
 module.exports = router;

--- a/routes/likes.js
+++ b/routes/likes.js
@@ -2,10 +2,10 @@ const express = require("express");
 const { addLike, removeLike } = require("../controller/likeController");
 const router = express.Router();
 
-router.use(express.json);
+router.use(express.json());
 
-router.put("/:id", addLike);
+router.post("/:id", addLike);
 
-router.put("/:id", removeLike);
+router.delete("/:id", removeLike);
 
 module.exports = router;


### PR DESCRIPTION
## 배경
- 프로젝트의 와이어프레임을 확인했을 때, 도서를 조회 화면 / 메인 화면 / 도서 상세 화면에 좋아요 개수를 출력하고 있었습니다.
- 또한 도서 상세 페이지의 요구 사항 중 주요 기능에 좋아요 기능이 있었습니다.
    - 좋아요 버튼을 클릭하면 좋아요 수가 올라가고, 좋아요를  클릭했다고 표시 해달라고 요구 사항에 작성 되어 있었습니다.

##  주요 구현 사항
- 좋아요 추가 및 삭제 API를 구현했습니다.
    - 유저 - 도서 간 관계는 1:N의 관계로 구현했습니다.
    - 유저가 도서에 좋아요를 누를 때는 CREATE, 좋아요를 취소했을 때는 DELETE로 기능을 구현했습니다.
- 전체 도서 조회, 상세 도서 조회의 SQL문을 수정해 좋아요 수가 출력되도록 했습니다.
   - 상세 도서 조회의 경우, 화면을 보고 있는 해당 유저가 좋아요를 클릭했는지 아닌지 확인할 수 있도록 좋아요 여부도 추가했습니다.
      - 클릭하지 않은 경우는 0, 클릭한 경우는 1로 구분하도록 구현했습니다.