### PR TITLE
[Feat] DB 테이블 명 변경

### DIFF
--- a/controller/bookController.js
+++ b/controller/bookController.js
@@ -5,8 +5,8 @@ const allReadBooks = (req, res) => {
     const { category_id, recent, limit, currentPage } = req.query;
     let offset = (parseInt(currentPage) - 1) * parseInt(limit);
     let values = [];
-    let likeSql = "SELECT count(*) FROM likes WHERE liked_book_id = books.id";
-    let sql = `SELECT *, (${likeSql}) AS likes FROM books`;
+    let likeSql = "SELECT count(*) FROM LIKES_TB WHERE liked_book_id = BOOKS_TB.id";
+    let sql = `SELECT *, (${likeSql}) AS likes FROM BOOKS_TB`;
 
     if (category_id && recent) {
         sql += " WHERE category_id = ? AND pub_date BETWEEN DATE_SUB(NOW(), INTERVAL 1 MONTH) AND NOW()";
@@ -43,10 +43,10 @@ const detailReadBook = (req, res) => {
     const { id } = req.params;
     const { user_id } = req.body;
 
-    let likeSql = "SELECT count(*) FROM likes WHERE liked_book_id = books.id";
-    let isLikeSql = "SELECT EXISTS (SELECT * FROM likes WHERE user_id = ? AND liked_book_id = ?)";
+    let likeSql = "SELECT count(*) FROM LIKES_TB WHERE liked_book_id = BOOKS_TB.id";
+    let isLikeSql = "SELECT EXISTS (SELECT * FROM LIKES_TB WHERE user_id = ? AND liked_book_id = ?)";
 
-    let sql = `SELECT *, (${likeSql}) AS likes, (${isLikeSql}) AS isLiked FROM books LEFT JOIN categories ON books.category_id = categories.category_id WHERE books.id = ?`;
+    let sql = `SELECT *, (${likeSql}) AS likes, (${isLikeSql}) AS isLiked FROM BOOKS_TB LEFT JOIN CATEGORIES_TB ON BOOKS_TB.category_id = CATEGORIES_TB.category_id WHERE BOOKS_TB.id = ?`;
 
     conn.query(sql, [parseInt(user_id), parseInt(id), parseInt(id)], (err, results) => {
         if (err) {

--- a/controller/categoryController.js
+++ b/controller/categoryController.js
@@ -2,7 +2,7 @@ const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 
 const allReadCategory = (req, res) => {
-    let allReadSql = "SELECT * FROM categories";
+    let allReadSql = "SELECT * FROM CATEGORIES_TB";
 
     conn.query(allReadSql, (err, results) => {
         if (err) {

--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -5,7 +5,7 @@ const addLike = (req, res) => {
     const { id } = req.params;
     const { user_id } = req.body;
 
-    let sql = "INSERT INTO likes (user_id, liked_book_id) VALUES (?, ?)";
+    let sql = "INSERT INTO LIKES_TB (user_id, liked_book_id) VALUES (?, ?)";
 
     conn.query(sql, [user_id, parseInt(id)], (err, results) => {
         if (err) {
@@ -26,7 +26,7 @@ const removeLike = (req, res) => {
     const { id } = req.params;
     const { user_id } = req.body;
 
-    let sql = "DELETE FROM likes WHERE user_id = ? AND liked_book_id = ?";
+    let sql = "DELETE FROM LIKES_TB WHERE user_id = ? AND liked_book_id = ?";
 
     conn.query(sql, [user_id, parseInt(id)], (err, results) => {
         if (err) {

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -10,7 +10,7 @@ const userJoin = (req, res) => {
     const { email, name, password } = req.body;
     const salt = crypto.randomBytes(10).toString('base64');
     const hashed = crypto.pbkdf2Sync(password, salt, 10000, 10, 'sha512').toString('base64');
-    const sql = "INSERT INTO users (email, name, password, salt) VALUES(?, ?, ?, ?)"
+    const sql = "INSERT INTO USERS_TB (email, name, password, salt) VALUES(?, ?, ?, ?)"
     const sqlArr = [email, name, hashed, salt];
 
     if (req.body == {}) {
@@ -31,7 +31,7 @@ const userJoin = (req, res) => {
 
 const userLogin = (req, res) => {
     const { email, password } = req.body;
-    let sql = "SELECT * FROM users WHERE email = ?";
+    let sql = "SELECT * FROM USERS_TB WHERE email = ?";
 
     conn.query(sql, email, (err, results) => {
         if (err) {
@@ -66,7 +66,7 @@ const userLogin = (req, res) => {
 
 const requestPasswordReset = (req, res) => {
     const { email } = req.body;
-    let sql = "SELECT * FROM users WHERE email = ?";
+    let sql = "SELECT * FROM USERS_TB WHERE email = ?";
 
     conn.query(sql, email, (err, results) => {
         if (err) {
@@ -91,7 +91,7 @@ const passwordReset = (req, res) => {
     const salt = crypto.randomBytes(10).toString('base64');
     const hashed = crypto.pbkdf2Sync(password, salt, 10000, 10, 'sha512').toString('base64');
 
-    let sql = "UPDATE users SET password = ?, salt = ? WHERE email = ?";
+    let sql = "UPDATE USERS_TB SET password = ?, salt = ? WHERE email = ?";
     let values = [hashed, salt, email];
 
     conn.query(sql, values, (err, results) => {


### PR DESCRIPTION
### 배경
- 데이터베이스의 네이밍 룰 중 이런 룰이 있었습니다. [참고](https://velog.io/@jkijki12/Database-%EC%9D%B4%EB%A6%84-%EC%A7%93%EA%B8%B0-%EC%96%B4%EB%A0%A4%EC%9A%B0%EC%84%B8%EC%9A%94)
- 데이터베이스 네이밍 룰에 따라 DB 데이터베이스의 테이블 명들을 변경해주기로 결정했습니다.

### 주요 구현 사항
- 기존의 테이블 명들을 전부 변경했습니다.
- AS-IS / TO-BE
   - users / USERS_TB
   - books / BOOKS_TB
   - categories / CATEGORIES_TB
   - likes / LIKES_TB