### PR TITLE
[Feat] 장바구니 API 구현

### DIFF
--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -45,7 +45,23 @@ const addToCarts = (req, res) => {
 }
 
 const removeToCarts = (req, res) => {
-    res.json({ message: "장바구니 도서 삭제" })
+    const { id } = req.params;
+
+    let sql = "DELETE FROM CART_ITEMS_TB WHERE id = ?";
+
+    conn.query(sql, parseInt(id), (err, results) => {
+        if (err) {
+            return res.status(StatusCodes.BAD_REQUEST).json({
+                message: err
+            })
+        }
+
+        if (results.affectedRows === 0) {
+            return res.status(StatusCodes.BAD_REQUEST).end();
+        } else {
+            return res.status(StatusCodes.OK).json(results);
+        }
+    })
 }
 
 module.exports = {

--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -1,0 +1,20 @@
+const conn = require("../db/mariadb");
+const { StatusCodes } = require("http-status-codes");
+
+const allReadCartItems = (req, res) => {
+    res.json({ message: "장바구니 조회" })
+}
+
+const addToCarts = (req, res) => {
+    res.json({ message: "장바구니 담기" })
+}
+
+const removeToCarts = (req, res) => {
+    res.json({ message: "장바구니 도서 삭제" })
+}
+
+module.exports = {
+    allReadCartItems,
+    addToCarts,
+    removeToCarts
+}

--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -2,7 +2,26 @@ const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 
 const allReadCartItems = (req, res) => {
-    res.json({ message: "장바구니 조회" })
+    const { user_id } = req.body;
+
+    let allReadSql = `SELECT CART_ITEMS_TB.id, book_id, title, summary, amount, price 
+                    FROM CART_ITEMS_TB LEFT JOIN BOOKS_TB 
+                    ON CART_ITEMS_TB.book_id = BOOKS_TB.id
+                    WHERE user_id = ?`;
+
+    conn.query(allReadSql, parseInt(user_id), (err, results) => {
+        if (err) {
+            return res.status(StatusCodes.BAD_REQUEST).json({
+                message: err
+            })
+        }
+
+        if (results[0]) {
+            return res.status(StatusCodes.OK).json(results);
+        } else {
+            return res.status(StatusCodes.NOT_FOUND).end();
+        }
+    })
 }
 
 const addToCarts = (req, res) => {

--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -6,7 +6,23 @@ const allReadCartItems = (req, res) => {
 }
 
 const addToCarts = (req, res) => {
-    res.json({ message: "장바구니 담기" })
+    const { book_id, amount, user_id } = req.body;
+
+    let sql = "INSERT INTO CART_ITEMS_TB (book_id, amount, user_id) VALUES (?, ?, ?)";
+
+    conn.query(sql, [parseInt(book_id), parseInt(amount), parseInt(user_id)], (err, results) => {
+        if (err) {
+            return res.status(StatusCodes.BAD_REQUEST).json({
+                message: err
+            })
+        }
+
+        if (results.affectedRows === 0) {
+            return res.status(StatusCodes.BAD_REQUEST).end();
+        } else {
+            return res.status(StatusCodes.OK).json(results);
+        }
+    })
 }
 
 const removeToCarts = (req, res) => {

--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -2,14 +2,18 @@ const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 
 const allReadCartItems = (req, res) => {
-    const { user_id } = req.body;
+    const { user_id, selected } = req.body;
 
     let allReadSql = `SELECT CART_ITEMS_TB.id, book_id, title, summary, amount, price 
                     FROM CART_ITEMS_TB LEFT JOIN BOOKS_TB 
                     ON CART_ITEMS_TB.book_id = BOOKS_TB.id
-                    WHERE user_id = ?`;
+                    WHERE user_id = ? `;
 
-    conn.query(allReadSql, parseInt(user_id), (err, results) => {
+    if (selected) {
+        allReadSql += "AND CART_ITEMS_TB.book_id IN (?)"
+    }
+
+    conn.query(allReadSql, [parseInt(user_id), selected], (err, results) => {
         if (err) {
             return res.status(StatusCodes.BAD_REQUEST).json({
                 message: err

--- a/routes/carts.js
+++ b/routes/carts.js
@@ -1,18 +1,18 @@
 const express = require("express");
+const {
+    allReadCartItems,
+    addToCarts,
+    removeToCarts,
+} = require("../controller/cartController");
 const router = express.Router();
 
-router.use(express.json);
 
-router.get("/", (req, res) => {
-    res.json({ message: "장바구니 조회" })
-});
+router.use(express.json());
 
-router.post("/", (req, res) => {
-    res.json({ message: "장바구니 담기" })
-});
+router.get("/", allReadCartItems);
 
-router.delete("/:id", (req, res) => {
-    res.json({ message: "장바구니 도서 삭제" })
-});
+router.post("/", addToCarts);
+
+router.delete("/:id", removeToCarts);
 
 module.exports = router;


### PR DESCRIPTION
### 배경
- 장바구니 페이지가 와이어프레임으로 제공되어 있었습니다.
- 장바구니 페이지의 요구 사항은 아래와 같습니다.
     - 장바구니 목록을 볼 수 있다.
     - 장바구니에 담은 상품을 지울 수 있다. 
     - 장바구니에 담은 상품을 주문할 수 있다.
        - 장바구니에서 개별 선택한 상품 목록을 볼 수 있어야 한다.


### 주요 기능 구현
- 장바구니 전체 목록 조회 API를 구현했습니다.
   - 유저 id를 받아 해당 유저가 담아놓은 장바구니 목록을 조회할 수 있도록 구현했습니다.
- 장바구니 추가 API를 구현했습니다.
    - 도서 id, count, 유저 id를 받아 post method를 통해 DB에 insert 하도록 구현했습니다.
- 장바구니 삭제 API를 구현했습니다.
   - 장바구니에 담긴 상품의 id를 이용해 DB에서 delete할 수 있도록 구현했습니다.
- 장바구니 예상 결제 목록 조회 API를 구현했습니다.
   - 장바구니 내에 담긴 상품들을 select 한 배열(도서 id)을 SQL 구문에 넘겨줘서 해당 상품들만 조회할 수 있도록 구현했습니다.