### PR TITLE
[Feat] 주문 API 구현

### DIFF
--- a/controller/orderController.js
+++ b/controller/orderController.js
@@ -1,0 +1,21 @@
+const conn = require("../db/mariadb");
+const { StatusCodes } = require("http-status-codes");
+
+
+const readAllOrder = (req, res) => {
+    res.json({ message: "결제 상품 전체 조회" })
+}
+
+const addToOrder = (req, res) => {
+    res.json({ message: "결제하기" })
+}
+
+const readDetailOrder = (req, res) => {
+    res.json({ message: "결제 상품 상세 조회" })
+}
+
+module.exports = {
+    readAllOrder,
+    addToOrder,
+    readDetailOrder
+}

--- a/controller/orderController.js
+++ b/controller/orderController.js
@@ -7,7 +7,62 @@ const readAllOrder = (req, res) => {
 }
 
 const addToOrder = (req, res) => {
-    res.json({ message: "결제하기" })
+    const { items, delivery, total_amount, total_price, user_id, first_book_title } = req.body;
+
+    // DELIVERY_TB INSERT (DELIVERY_TB id 있어야 함)
+    let deliverySql = "INSERT INTO DELIVERY_TB (address, receiver, contact) VALUES (?, ?, ?)";
+    let deliveryValues = [delivery.address, delivery.receiver, delivery.contact];
+
+    // ORDERS_TB INSERT (ORDERS_TB id 있어야 함)
+    let ordersSql = `INSERT INTO ORDERS_TB (book_title, total_amount, total_price, user_id, delivery_id) VALUES (?, ?, ?, ?, ?)`;
+    let ordersValues = [first_book_title, total_amount, total_price, user_id];
+
+    // ORDERED_BOOKS_TB INSERT (가장 마지막에 되어야 함)
+    let orderedBooksSql = `INSERT INTO ORDERED_BOOKS_TB (order_id, book_id, amount) VALUES ?`;
+    let orderedBooksValues = [];
+
+    // 쿼리 실행
+    conn.query(deliverySql, deliveryValues, (err, deliveryResults) => {
+        if (err) {
+            return res.status(StatusCodes.BAD_REQUEST).json({
+                message: err
+            });
+        }
+
+        // 결과에서 delivery_id를 가져올 수 있으면 가져오기
+        const delivery_id = deliveryResults.insertId;
+
+        // ORDERS_TB 쿼리 계속 진행
+        conn.query(ordersSql, [...ordersValues, delivery_id], (err, ordersResults) => {
+            if (err) {
+                return res.status(StatusCodes.BAD_REQUEST).json({
+                    message: err
+                });
+            }
+
+            // 결과에서 order_id를 가져올 수 있으면 가져오기
+            const order_id = ordersResults.insertId;
+
+            // ORDERED_BOOKS_TB 쿼리 계속 진행
+            items.forEach((item) => {
+                orderedBooksValues.push([order_id, item.book_id, item.amount]);
+            });
+
+            conn.query(orderedBooksSql, [orderedBooksValues], (err, orderedBooksResults) => {
+                if (err) {
+                    return res.status(StatusCodes.BAD_REQUEST).json({
+                        message: err
+                    });
+                }
+
+                if (orderedBooksResults.affectedRows === 0) {
+                    return res.status(StatusCodes.BAD_REQUEST).end();
+                } else {
+                    return res.status(StatusCodes.OK).json(orderedBooksResults);
+                }
+            });
+        });
+    });
 }
 
 const readDetailOrder = (req, res) => {

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -1,19 +1,18 @@
 const express = require("express");
+const {
+    readAllOrder,
+    addToOrder,
+    readDetailOrder
+} = require("../controller/orderController");
 const router = express.Router();
 
-router.use(express.json);
+router.use(express.json());
 
-router.get("/", (req, res) => {
-    res.json({ message: "결제 상품 전체 조회" })
-});
+router.get("/", readAllOrder);
 
-router.post("/", (req, res) => {
-    res.json({ message: "결제하기" })
-});
+router.post("/", addToOrder);
 
-router.get("/:id", (req, res) => {
-    res.json({ message: "결제 상품 상세 조회" })
-});
+router.get("/:id", readDetailOrder);
 
 
 module.exports = router;


### PR DESCRIPTION
## 배경
- 와이어 프레임의 주문서 작성 및 주문서 목록 페이지가 있었다.
- 주문서 작성 페이지의 주요 기능
    - 장바구니에서 선택한 상품 목록 노출
    - 결제하기 요청 (주문서 입력)
- 주문서 목록 페이지의 주요 기능
    - 작성한 주문서 목록 노충
    - 배송 추적
    - 상세 정보
- 즉 주문서 작성에 필요한 데이터를 DB에 insert하고, 조회해야 함을 알 수 있었다.

## 주요 구현 기능
- 주문 API 뼈대를 구현
- 주문 API 중 Insert에 관련된 api 구현
    - 주문 목록을 insert 하기 위해서는 3개의 SQL 쿼리문이 필요했다.
       - DELIVERY_TB (배송지 저장) / ORDERS_TB (주문서 저장) / ORDERED_BOOKS_TB (주문한 책 저장)
       - 각각의 Table에 insert를 해야 했고, DELIVERY_TB와 ORDERS_TB에 먼저 데이터가 들어가야지 ORDERED_BOOKS_TB에도 데이터를 넣을 수 있었다.
       - 차례대로 쿼리를 실행하기 위해 쿼리를 중첩해서 작성했다.