### PR TITLE
[Feat] 주문 목록 전체 조회 및 상세 조회 API 구현

### DIFF
--- a/controller/orderController.js
+++ b/controller/orderController.js
@@ -2,8 +2,18 @@ const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 
 
-const readAllOrder = (req, res) => {
-    res.json({ message: "결제 상품 전체 조회" })
+const readAllOrder = async (req, res) => {
+    let sql = `SELECT 
+    ORDERS_TB.id, created_at, receiver, contact, address, book_title, total_amount, total_price 
+    FROM ORDERS_TB LEFT JOIN DELIVERY_TB ON ORDERS_TB.delivery_id = DELIVERY_TB.id`;
+
+    let [results, fields] = await conn.query(sql);
+
+    if (results) {
+        res.status(StatusCodes.OK).json(results);
+    } else {
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+    }
 }
 
 const addToOrder = async (req, res) => {

--- a/controller/orderController.js
+++ b/controller/orderController.js
@@ -73,8 +73,21 @@ const removeToCartItem = async (items) => {
     return [results, fields] = await conn.query(sql, [items]);
 }
 
-const readDetailOrder = (req, res) => {
-    res.json({ message: "결제 상품 상세 조회" })
+const readDetailOrder = async (req, res) => {
+    const { id } = req.params;
+
+    let sql = `SELECT 
+    book_id, title, author, price, amount 
+    FROM ORDERED_BOOKS_TB LEFT JOIN BOOKS_TB ON ORDERED_BOOKS_TB.book_id = BOOKS_TB.id 
+    WHERE order_id = ?`;
+
+    let [results, fields] = await conn.query(sql, parseInt(id));
+
+    if (results) {
+        res.status(StatusCodes.OK).json(results);
+    } else {
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+    }
 }
 
 module.exports = {

--- a/controller/orderController.js
+++ b/controller/orderController.js
@@ -7,11 +7,16 @@ const readAllOrder = async (req, res) => {
     ORDERS_TB.id, created_at, receiver, contact, address, book_title, total_amount, total_price 
     FROM ORDERS_TB LEFT JOIN DELIVERY_TB ON ORDERS_TB.delivery_id = DELIVERY_TB.id`;
 
-    let [results, fields] = await conn.query(sql);
+    try {
+        let [results, fields] = await conn.query(sql);
 
-    if (results) {
-        res.status(StatusCodes.OK).json(results);
-    } else {
+        if (results) {
+            res.status(StatusCodes.OK).json(results);
+        } else {
+            res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+        }
+    } catch (error) {
+        console.error("Error reading orders:", error);
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
     }
 }
@@ -81,11 +86,16 @@ const readDetailOrder = async (req, res) => {
     FROM ORDERED_BOOKS_TB LEFT JOIN BOOKS_TB ON ORDERED_BOOKS_TB.book_id = BOOKS_TB.id 
     WHERE order_id = ?`;
 
-    let [results, fields] = await conn.query(sql, parseInt(id));
+    try {
+        let [results, fields] = await conn.query(sql, parseInt(id));
 
-    if (results) {
-        res.status(StatusCodes.OK).json(results);
-    } else {
+        if (results) {
+            res.status(StatusCodes.OK).json(results);
+        } else {
+            res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
+        }
+    } catch (error) {
+        console.error("Error reading orders detail:", error);
         res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
     }
 }


### PR DESCRIPTION
## 배경
- order API 중 주문 목록 전체 조회와 상세 조회 API를 구현해야 했다.

## 주요 기능 구현
- 주문 목록 전체 조회 API를 구현했다.
- 주문 목록 상세 조회 API를 구현했다.
- 두 API 모두 `results`가 없을 때는 빈 배열을 반환하도록 구현했고, try-catch 구문으로 예외처리를 해줘 예외 상황에서도 서버가 다운되지 않도록 했다.

## 수정 사항
- `removeToCartItem` 함수와 `readDetailOrder` 함수에서도 비동기 함수를 사용하고 있어 try-catch로 에러를 처리했다.
- `readDetailOrder` 함수 파라미터 타입 중 `conn.query()`에 전달되는 두 번째 파라미터는 배열이어야 해서 `parseInt(id)` 대신 `[parseInt(id)]`로 변경해 주었다.
- 트랜잭션 롤백 처리
   - 현재 코드에서는 하나의 쿼리에 대한 결과가 실패하면 트랜잭션을 롤백하고 에러 응답을 보내고 있는데, 트랜잭션이 롤백되지 않은 상태에서 다음 쿼리에서 에러가 발생하면 롤백이 제대로 이루어지지 않을 수 있다는 문제점을 발견했다.
   - 모든 쿼리가 성공했을 때에만 커밋을 하는 것이 바람직하기 때문에 `await conn.commit()`를 트랜잭션의 마지막에 위치시켜 모든 쿼리가 성공했을 때에만 커밋하도록 했다.
- `errorInsertSQL` 함수의 파라미터에 `queryName` 추가
   - `queryName`을 추가하여 어떤 쿼리에서 문제가 발생했는지 구체적으로 로깅하도록 수정

## 기능 구현 및 수정 후
- 트랜잭션을 안전하게 처리하면서도 에러에 대한 세부 정보를 적절히 로깅하고, 클라이언트에게 적절한 에러 응답을 전달할 수 있게 된 것 같다.
- 코드의 안정성을 많이 높인 것 같다.