### PR TITLE
[Fix] API 핸들러 수정

### DIFF
--- a/controller/bookController.js
+++ b/controller/bookController.js
@@ -1,7 +1,7 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 
-const allReadBooks = (req, res) => {
+const allReadBooks = async (req, res) => {
     const { category_id, recent, limit, currentPage } = req.query;
     let offset = (parseInt(currentPage) - 1) * parseInt(limit);
     let values = [];
@@ -21,25 +21,18 @@ const allReadBooks = (req, res) => {
     sql += " LIMIT ? OFFSET ?";
     values = [...values, parseInt(limit), parseInt(offset)];
 
-    conn.query(sql, values, (err, results) => {
-        if (err) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-                message: err
-            })
-        }
+    let [results, fields] = await conn.query(sql, values);
 
-        if (results[0]) {
-            return res.status(StatusCodes.OK).json(results);
-        } else {
-            return res.status(StatusCodes.NOT_FOUND).json({
-                massage: "존재하지 않는 도서입니다."
-            });
-        }
-    })
-
+    if (results[0]) {
+        return res.status(StatusCodes.OK).json(results);
+    } else {
+        return res.status(StatusCodes.NOT_FOUND).json({
+            massage: "존재하지 않는 도서입니다."
+        });
+    }
 }
 
-const detailReadBook = (req, res) => {
+const detailReadBook = async (req, res) => {
     const { id } = req.params;
     const { user_id } = req.body;
 
@@ -48,21 +41,15 @@ const detailReadBook = (req, res) => {
 
     let sql = `SELECT *, (${likeSql}) AS likes, (${isLikeSql}) AS isLiked FROM BOOKS_TB LEFT JOIN CATEGORIES_TB ON BOOKS_TB.category_id = CATEGORIES_TB.category_id WHERE BOOKS_TB.id = ?`;
 
-    conn.query(sql, [parseInt(user_id), parseInt(id), parseInt(id)], (err, results) => {
-        if (err) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-                message: err
-            })
-        }
+    let [results, fields] = await conn.query(sql, [parseInt(user_id), parseInt(id), parseInt(id)]);
 
-        if (results[0]) {
-            return res.status(StatusCodes.OK).json(results);
-        } else {
-            return res.status(StatusCodes.NOT_FOUND).json({
-                massage: "존재하지 않는 도서입니다."
-            });
-        }
-    })
+    if (results[0]) {
+        return res.status(StatusCodes.OK).json(results);
+    } else {
+        return res.status(StatusCodes.NOT_FOUND).json({
+            massage: "존재하지 않는 도서입니다."
+        });
+    }
 }
 
 module.exports = {

--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -1,71 +1,53 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 
-const allReadCartItems = (req, res) => {
+const allReadCartItems = async (req, res) => {
     const { user_id, selected } = req.body;
 
-    let allReadSql = `SELECT CART_ITEMS_TB.id, book_id, title, summary, amount, price 
+    let sql = `SELECT CART_ITEMS_TB.id, book_id, title, summary, amount, price 
                     FROM CART_ITEMS_TB LEFT JOIN BOOKS_TB 
                     ON CART_ITEMS_TB.book_id = BOOKS_TB.id
                     WHERE user_id = ? `;
 
     if (selected) {
-        allReadSql += "AND CART_ITEMS_TB.book_id IN (?)"
+        sql += "AND CART_ITEMS_TB.book_id IN (?)"
     }
 
-    conn.query(allReadSql, [parseInt(user_id), selected], (err, results) => {
-        if (err) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-                message: err
-            })
-        }
+    let [results, fields] = await conn.query(sql, [parseInt(user_id), selected]);
 
-        if (results[0]) {
-            return res.status(StatusCodes.OK).json(results);
-        } else {
-            return res.status(StatusCodes.NOT_FOUND).end();
-        }
-    })
+    if (results[0]) {
+        return res.status(StatusCodes.OK).json(results);
+    } else {
+        return res.status(StatusCodes.NOT_FOUND).end();
+    }
 }
 
-const addToCarts = (req, res) => {
+const addToCarts = async (req, res) => {
     const { book_id, amount, user_id } = req.body;
 
     let sql = "INSERT INTO CART_ITEMS_TB (book_id, amount, user_id) VALUES (?, ?, ?)";
 
-    conn.query(sql, [parseInt(book_id), parseInt(amount), parseInt(user_id)], (err, results) => {
-        if (err) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-                message: err
-            })
-        }
+    let [results, fields] = await conn.query(sql, [parseInt(book_id), parseInt(amount), parseInt(user_id)]);
 
-        if (results.affectedRows === 0) {
-            return res.status(StatusCodes.BAD_REQUEST).end();
-        } else {
-            return res.status(StatusCodes.OK).json(results);
-        }
-    })
+    if (results.affectedRows === 0) {
+        return res.status(StatusCodes.BAD_REQUEST).end();
+    } else {
+        return res.status(StatusCodes.OK).json(results);
+    }
 }
 
-const removeToCarts = (req, res) => {
+const removeToCarts = async (req, res) => {
     const { id } = req.params;
 
     let sql = "DELETE FROM CART_ITEMS_TB WHERE id = ?";
 
-    conn.query(sql, parseInt(id), (err, results) => {
-        if (err) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-                message: err
-            })
-        }
+    let [results, fields] = await conn.query(sql, [parseInt(id)]);
 
-        if (results.affectedRows === 0) {
-            return res.status(StatusCodes.BAD_REQUEST).end();
-        } else {
-            return res.status(StatusCodes.OK).json(results);
-        }
-    })
+    if (results.affectedRows === 0) {
+        return res.status(StatusCodes.BAD_REQUEST).end();
+    } else {
+        return res.status(StatusCodes.OK).json(results);
+    }
 }
 
 module.exports = {

--- a/controller/categoryController.js
+++ b/controller/categoryController.js
@@ -1,22 +1,16 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 
-const allReadCategory = (req, res) => {
-    let allReadSql = "SELECT * FROM CATEGORIES_TB";
+const allReadCategory = async (req, res) => {
+    let sql = "SELECT * FROM CATEGORIES_TB";
 
-    conn.query(allReadSql, (err, results) => {
-        if (err) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-                message: err
-            })
-        }
+    let [results, fields] = await conn.query(sql);
 
-        if (results[0]) {
-            return res.status(StatusCodes.OK).json(results);
-        } else {
-            return res.status(StatusCodes.NOT_FOUND).end();
-        }
-    })
+    if (results[0]) {
+        return res.status(StatusCodes.OK).json(results);
+    } else {
+        return res.status(StatusCodes.NOT_FOUND).end();
+    }
 }
 
 module.exports = allReadCategory;

--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -1,46 +1,34 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 
-const addLike = (req, res) => {
+const addLike = async (req, res) => {
     const { id } = req.params;
     const { user_id } = req.body;
 
     let sql = "INSERT INTO LIKES_TB (user_id, liked_book_id) VALUES (?, ?)";
 
-    conn.query(sql, [user_id, parseInt(id)], (err, results) => {
-        if (err) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-                message: err
-            })
-        }
+    let [results, fields] = await conn.query(sql, [user_id, parseInt(id)]);
 
-        if (results.affectedRows === 0) {
-            return res.status(StatusCodes.BAD_REQUEST).end();
-        } else {
-            return res.status(StatusCodes.OK).json(results);
-        }
-    })
+    if (results.affectedRows === 0) {
+        return res.status(StatusCodes.BAD_REQUEST).end();
+    } else {
+        return res.status(StatusCodes.OK).json(results);
+    }
 };
 
-const removeLike = (req, res) => {
+const removeLike = async (req, res) => {
     const { id } = req.params;
     const { user_id } = req.body;
 
     let sql = "DELETE FROM LIKES_TB WHERE user_id = ? AND liked_book_id = ?";
 
-    conn.query(sql, [user_id, parseInt(id)], (err, results) => {
-        if (err) {
-            return res.status(StatusCodes.BAD_REQUEST).json({
-                message: err
-            })
-        }
+    let [results, fields] = await conn.query(sql, [user_id, parseInt(id)]);
 
-        if (results.affectedRows === 0) {
-            return res.status(StatusCodes.BAD_REQUEST).end();
-        } else {
-            return res.status(StatusCodes.OK).json(results);
-        }
-    })
+    if (results.affectedRows === 0) {
+        return res.status(StatusCodes.BAD_REQUEST).end();
+    } else {
+        return res.status(StatusCodes.OK).json(results);
+    }
 };
 
 module.exports = { addLike, removeLike }


### PR DESCRIPTION
## 배경
- DB를  `mysql.createPool()` 메소드로 연결하면서 다른 핸들러에도 해당 메소드를 사용하는 로직으로 변경해야 했다.

## 주요 변경 사항
- 핸들러 함수를 async-await 지시자를 사용하는 함수로 변경
- 기존의 `conn.query()` 을 이용해 그 안에서 로직을 작성했던 것에서 `let [results, fields] = await conn.query()` 으로 변경해 안에서 작성했던 로직들을 밖으로 꺼내어 작성

