### PR TITLE
[Feat] 좋아요 API에 JWT 추가

### DIFF
--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -1,18 +1,14 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
-const jwt = require("jsonwebtoken");
-const dotenv = require("dotenv");
-
-dotenv.config();
+const { decodedJWT } = require("../helper");
 
 const addLike = async (req, res) => {
     const { id } = req.params;
-    const receivedJwt = req.headers["authorization"];
-    let decodedUserInfo = jwt.decode(receivedJwt, process.env.PRIVATE_KEY);
+    let decoded = decodedJWT(req.headers["authorization"]);
 
     let sql = "INSERT INTO LIKES_TB (user_id, liked_book_id) VALUES (?, ?)";
 
-    let [results, fields] = await conn.query(sql, [decodedUserInfo.id, parseInt(id)]);
+    let [results, fields] = await conn.query(sql, [decoded.id, parseInt(id)]);
 
     if (results.affectedRows === 0) {
         return res.status(StatusCodes.BAD_REQUEST).end();
@@ -23,11 +19,11 @@ const addLike = async (req, res) => {
 
 const removeLike = async (req, res) => {
     const { id } = req.params;
-    const { user_id } = req.body;
+    let decoded = decodedJWT(req.headers["authorization"]);
 
     let sql = "DELETE FROM LIKES_TB WHERE user_id = ? AND liked_book_id = ?";
 
-    let [results, fields] = await conn.query(sql, [user_id, parseInt(id)]);
+    let [results, fields] = await conn.query(sql, [decoded.id, parseInt(id)]);
 
     if (results.affectedRows === 0) {
         return res.status(StatusCodes.BAD_REQUEST).end();

--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -1,13 +1,18 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
+const jwt = require("jsonwebtoken");
+const dotenv = require("dotenv");
+
+dotenv.config();
 
 const addLike = async (req, res) => {
     const { id } = req.params;
-    const { user_id } = req.body;
+    const receivedJwt = req.headers["authorization"];
+    let decodedUserInfo = jwt.decode(receivedJwt, process.env.PRIVATE_KEY);
 
     let sql = "INSERT INTO LIKES_TB (user_id, liked_book_id) VALUES (?, ?)";
 
-    let [results, fields] = await conn.query(sql, [user_id, parseInt(id)]);
+    let [results, fields] = await conn.query(sql, [decodedUserInfo.id, parseInt(id)]);
 
     if (results.affectedRows === 0) {
         return res.status(StatusCodes.BAD_REQUEST).end();

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -35,6 +35,7 @@ const userLogin = async (req, res) => {
 
     if (results[0] && results[0].password == pwdHashed) {
         const token = jwt.sign({
+            id: results[0].id,
             email: results[0].email
         }, process.env.PRIVATE_KEY, {
             expiresIn: '5m',

--- a/helper/index.js
+++ b/helper/index.js
@@ -1,0 +1,10 @@
+const jwt = require("jsonwebtoken");
+const dotenv = require("dotenv");
+
+dotenv.config();
+
+const decodedJWT = (authorization) => {
+    return jwt.decode(authorization, process.env.PRIVATE_KEY);
+}
+
+module.exports = { decodedJWT };


### PR DESCRIPTION
## 배경
- 처음에 `req.body`로 user id를 받아와서 로직을 구현하고 있었다.
- `req.body`로 user id를 받고 있던 부분을 jwt로 받아서 좀 더 보안을 고려하기로 했다.

## 주요 구현
- 로그인 api를 통해 받은 jwt를 `authorization` 헤더로 보내주었고, 받은 jwt를 복호화해 안에 들어있는 id를 꺼내어 좋아요 추가 및 삭제 API에 적용했다.
- jwt를 복호화 하는 부분은 모듈화할 수 있겠다고 판단해 helper 함수로 분리했다.
  - 주로 토큰을 디코딩하는 작업을 수행하기 때문에, 재사용 가능하고 특정한 기능을 수행하는 보조 기능으로 봐서 헬퍼 함수라고 네이밍했다.