### PR TITLE
[Feat] cart API에 JWT 추가

### DIFF
--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -4,7 +4,7 @@ const { decodedJWT } = require("../helper");
 
 const allReadCartItems = async (req, res) => {
     const { selected } = req.body;
-    const decoded = decodedJWT(req.headers["authorization"]);
+    const decoded = decodedJWT(req, res);
 
     let sql = `SELECT CART_ITEMS_TB.id, book_id, title, summary, amount, price 
                     FROM CART_ITEMS_TB LEFT JOIN BOOKS_TB 
@@ -14,6 +14,8 @@ const allReadCartItems = async (req, res) => {
     if (selected) {
         sql += "AND CART_ITEMS_TB.id IN (?)"
     }
+
+    console.log(decoded);
 
     let [results, fields] = await conn.query(sql, [decoded.id, selected]);
 
@@ -26,7 +28,7 @@ const allReadCartItems = async (req, res) => {
 
 const addToCarts = async (req, res) => {
     const { book_id, amount } = req.body;
-    const decoded = decodedJWT(req.headers["authorization"]);
+    const decoded = decodedJWT(req, res);
 
     let sql = "INSERT INTO CART_ITEMS_TB (book_id, amount, user_id) VALUES (?, ?, ?)";
 

--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -1,10 +1,17 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 const { decodedJWT } = require("../helper");
+const { TokenExpiredError } = require("jsonwebtoken");
 
 const allReadCartItems = async (req, res) => {
     const { selected } = req.body;
-    const decoded = decodedJWT(req, res);
+    const decoded = decodedJWT(req);
+
+    if (decoded instanceof TokenExpiredError) {
+        return res.status(StatusCodes.UNAUTHORIZED).json({
+            "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
+        })
+    }
 
     let sql = `SELECT CART_ITEMS_TB.id, book_id, title, summary, amount, price 
                     FROM CART_ITEMS_TB LEFT JOIN BOOKS_TB 
@@ -14,8 +21,6 @@ const allReadCartItems = async (req, res) => {
     if (selected) {
         sql += "AND CART_ITEMS_TB.id IN (?)"
     }
-
-    console.log(decoded);
 
     let [results, fields] = await conn.query(sql, [decoded.id, selected]);
 
@@ -28,7 +33,13 @@ const allReadCartItems = async (req, res) => {
 
 const addToCarts = async (req, res) => {
     const { book_id, amount } = req.body;
-    const decoded = decodedJWT(req, res);
+    const decoded = decodedJWT(req);
+
+    if (decoded instanceof TokenExpiredError) {
+        return res.status(StatusCodes.UNAUTHORIZED).json({
+            "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
+        })
+    }
 
     let sql = "INSERT INTO CART_ITEMS_TB (book_id, amount, user_id) VALUES (?, ?, ?)";
 

--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -1,7 +1,7 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 const { decodedJWT } = require("../helper");
-const { TokenExpiredError } = require("jsonwebtoken");
+const { TokenExpiredError, JsonWebTokenError } = require("jsonwebtoken");
 
 const allReadCartItems = async (req, res) => {
     const { selected } = req.body;
@@ -10,6 +10,12 @@ const allReadCartItems = async (req, res) => {
     if (decoded instanceof TokenExpiredError) {
         return res.status(StatusCodes.UNAUTHORIZED).json({
             "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
+        })
+    }
+
+    if (decoded instanceof JsonWebTokenError) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+            "message": "잘못된 토큰입니다."
         })
     }
 
@@ -38,6 +44,12 @@ const addToCarts = async (req, res) => {
     if (decoded instanceof TokenExpiredError) {
         return res.status(StatusCodes.UNAUTHORIZED).json({
             "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
+        })
+    }
+
+    if (decoded instanceof JsonWebTokenError) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+            "message": "잘못된 토큰입니다."
         })
     }
 

--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -1,23 +1,10 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 const { decodedJWT } = require("../helper");
-const { TokenExpiredError, JsonWebTokenError } = require("jsonwebtoken");
 
 const allReadCartItems = async (req, res) => {
     const { selected } = req.body;
-    const decoded = decodedJWT(req);
-
-    if (decoded instanceof TokenExpiredError) {
-        return res.status(StatusCodes.UNAUTHORIZED).json({
-            "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
-        })
-    }
-
-    if (decoded instanceof JsonWebTokenError) {
-        return res.status(StatusCodes.BAD_REQUEST).json({
-            "message": "잘못된 토큰입니다."
-        })
-    }
+    const decoded = decodedJWT(req, res);
 
     let sql = `SELECT CART_ITEMS_TB.id, book_id, title, summary, amount, price 
                     FROM CART_ITEMS_TB LEFT JOIN BOOKS_TB 
@@ -39,19 +26,7 @@ const allReadCartItems = async (req, res) => {
 
 const addToCarts = async (req, res) => {
     const { book_id, amount } = req.body;
-    const decoded = decodedJWT(req);
-
-    if (decoded instanceof TokenExpiredError) {
-        return res.status(StatusCodes.UNAUTHORIZED).json({
-            "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
-        })
-    }
-
-    if (decoded instanceof JsonWebTokenError) {
-        return res.status(StatusCodes.BAD_REQUEST).json({
-            "message": "잘못된 토큰입니다."
-        })
-    }
+    const decoded = decodedJWT(req, res);
 
     let sql = "INSERT INTO CART_ITEMS_TB (book_id, amount, user_id) VALUES (?, ?, ?)";
 

--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -1,8 +1,10 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
+const { decodedJWT } = require("../helper");
 
 const allReadCartItems = async (req, res) => {
-    const { user_id, selected } = req.body;
+    const { selected } = req.body;
+    const decoded = decodedJWT(req.headers["authorization"]);
 
     let sql = `SELECT CART_ITEMS_TB.id, book_id, title, summary, amount, price 
                     FROM CART_ITEMS_TB LEFT JOIN BOOKS_TB 
@@ -10,10 +12,10 @@ const allReadCartItems = async (req, res) => {
                     WHERE user_id = ? `;
 
     if (selected) {
-        sql += "AND CART_ITEMS_TB.book_id IN (?)"
+        sql += "AND CART_ITEMS_TB.id IN (?)"
     }
 
-    let [results, fields] = await conn.query(sql, [parseInt(user_id), selected]);
+    let [results, fields] = await conn.query(sql, [decoded.id, selected]);
 
     if (results[0]) {
         return res.status(StatusCodes.OK).json(results);
@@ -23,11 +25,12 @@ const allReadCartItems = async (req, res) => {
 }
 
 const addToCarts = async (req, res) => {
-    const { book_id, amount, user_id } = req.body;
+    const { book_id, amount } = req.body;
+    const decoded = decodedJWT(req.headers["authorization"]);
 
     let sql = "INSERT INTO CART_ITEMS_TB (book_id, amount, user_id) VALUES (?, ?, ?)";
 
-    let [results, fields] = await conn.query(sql, [parseInt(book_id), parseInt(amount), parseInt(user_id)]);
+    let [results, fields] = await conn.query(sql, [parseInt(book_id), parseInt(amount), decoded.id]);
 
     if (results.affectedRows === 0) {
         return res.status(StatusCodes.BAD_REQUEST).end();

--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -1,23 +1,10 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 const { decodedJWT } = require("../helper");
-const { TokenExpiredError } = require("jsonwebtoken");
 
 const addLike = async (req, res) => {
     const { id } = req.params;
-    const decoded = decodedJWT(req);
-
-    if (decoded instanceof TokenExpiredError) {
-        return res.status(StatusCodes.UNAUTHORIZED).json({
-            "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
-        })
-    }
-
-    if (decoded instanceof JsonWebTokenError) {
-        return res.status(StatusCodes.BAD_REQUEST).json({
-            "message": "잘못된 토큰입니다."
-        })
-    }
+    const decoded = decodedJWT(req, res);
 
     let sql = "INSERT INTO LIKES_TB (user_id, liked_book_id) VALUES (?, ?)";
 
@@ -32,19 +19,7 @@ const addLike = async (req, res) => {
 
 const removeLike = async (req, res) => {
     const { id } = req.params;
-    const decoded = decodedJWT(req);
-
-    if (decoded instanceof TokenExpiredError) {
-        return res.status(StatusCodes.UNAUTHORIZED).json({
-            "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
-        })
-    }
-
-    if (decoded instanceof JsonWebTokenError) {
-        return res.status(StatusCodes.BAD_REQUEST).json({
-            "message": "잘못된 토큰입니다."
-        })
-    }
+    const decoded = decodedJWT(req, res);
 
     let sql = "DELETE FROM LIKES_TB WHERE user_id = ? AND liked_book_id = ?";
 

--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -13,6 +13,11 @@ const addLike = async (req, res) => {
         })
     }
 
+    if (decoded instanceof JsonWebTokenError) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+            "message": "잘못된 토큰입니다."
+        })
+    }
 
     let sql = "INSERT INTO LIKES_TB (user_id, liked_book_id) VALUES (?, ?)";
 
@@ -32,6 +37,12 @@ const removeLike = async (req, res) => {
     if (decoded instanceof TokenExpiredError) {
         return res.status(StatusCodes.UNAUTHORIZED).json({
             "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
+        })
+    }
+
+    if (decoded instanceof JsonWebTokenError) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+            "message": "잘못된 토큰입니다."
         })
     }
 

--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -4,7 +4,7 @@ const { decodedJWT } = require("../helper");
 
 const addLike = async (req, res) => {
     const { id } = req.params;
-    let decoded = decodedJWT(req.headers["authorization"]);
+    const decoded = decodedJWT(req, res);
 
     let sql = "INSERT INTO LIKES_TB (user_id, liked_book_id) VALUES (?, ?)";
 
@@ -19,7 +19,7 @@ const addLike = async (req, res) => {
 
 const removeLike = async (req, res) => {
     const { id } = req.params;
-    let decoded = decodedJWT(req.headers["authorization"]);
+    const decoded = decodedJWT(req, res);
 
     let sql = "DELETE FROM LIKES_TB WHERE user_id = ? AND liked_book_id = ?";
 

--- a/controller/likeController.js
+++ b/controller/likeController.js
@@ -1,10 +1,18 @@
 const conn = require("../db/mariadb");
 const { StatusCodes } = require("http-status-codes");
 const { decodedJWT } = require("../helper");
+const { TokenExpiredError } = require("jsonwebtoken");
 
 const addLike = async (req, res) => {
     const { id } = req.params;
-    const decoded = decodedJWT(req, res);
+    const decoded = decodedJWT(req);
+
+    if (decoded instanceof TokenExpiredError) {
+        return res.status(StatusCodes.UNAUTHORIZED).json({
+            "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
+        })
+    }
+
 
     let sql = "INSERT INTO LIKES_TB (user_id, liked_book_id) VALUES (?, ?)";
 
@@ -19,7 +27,13 @@ const addLike = async (req, res) => {
 
 const removeLike = async (req, res) => {
     const { id } = req.params;
-    const decoded = decodedJWT(req, res);
+    const decoded = decodedJWT(req);
+
+    if (decoded instanceof TokenExpiredError) {
+        return res.status(StatusCodes.UNAUTHORIZED).json({
+            "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
+        })
+    }
 
     let sql = "DELETE FROM LIKES_TB WHERE user_id = ? AND liked_book_id = ?";
 

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -38,14 +38,13 @@ const userLogin = async (req, res) => {
             id: results[0].id,
             email: results[0].email
         }, process.env.PRIVATE_KEY, {
-            expiresIn: '5m',
+            expiresIn: '1m',
             issuer: "jeong"
         })
 
         res.cookie("token", token, {
             httpOnly: true
         })
-        console.log(token);
 
         return res.status(StatusCodes.OK).json(results);
     } else {

--- a/helper/index.js
+++ b/helper/index.js
@@ -1,14 +1,29 @@
 const jwt = require("jsonwebtoken");
 const dotenv = require("dotenv");
+const { StatusCodes } = require("http-status-codes");
+const { TokenExpiredError, JsonWebTokenError } = require("jsonwebtoken");
 
 dotenv.config();
 
-const decodedJWT = (req) => {
+const decodedJWT = (req, res) => {
     try {
         let receivedJWT = req.headers["authorization"]
         return jwt.verify(receivedJWT, process.env.PRIVATE_KEY);
     } catch (err) {
         console.error(err);
+
+        if (err instanceof TokenExpiredError) {
+            return res.status(StatusCodes.UNAUTHORIZED).json({
+                "message": "로그인 세션이 만료되었습니다. 다시 로그인해 주세요."
+            })
+        }
+
+        if (err instanceof JsonWebTokenError) {
+            return res.status(StatusCodes.BAD_REQUEST).json({
+                "message": "잘못된 토큰입니다."
+            })
+        }
+
         return err;
     }
 }

--- a/helper/index.js
+++ b/helper/index.js
@@ -1,10 +1,20 @@
 const jwt = require("jsonwebtoken");
 const dotenv = require("dotenv");
+const { StatusCodes } = require("http-status-codes");
 
 dotenv.config();
 
-const decodedJWT = (authorization) => {
-    return jwt.decode(authorization, process.env.PRIVATE_KEY);
+const decodedJWT = (req, res) => {
+    try {
+        let receivedJWT = req.headers["authorization"]
+        return jwt.verify(receivedJWT, process.env.PRIVATE_KEY);
+    } catch (err) {
+        console.error(err);
+
+        return res.status(StatusCodes.UNAUTHORIZED).json({
+            "message": "로그인 세션이 만료되었습니다."
+        });
+    }
 }
 
 module.exports = { decodedJWT };

--- a/helper/index.js
+++ b/helper/index.js
@@ -1,19 +1,15 @@
 const jwt = require("jsonwebtoken");
 const dotenv = require("dotenv");
-const { StatusCodes } = require("http-status-codes");
 
 dotenv.config();
 
-const decodedJWT = (req, res) => {
+const decodedJWT = (req) => {
     try {
         let receivedJWT = req.headers["authorization"]
         return jwt.verify(receivedJWT, process.env.PRIVATE_KEY);
     } catch (err) {
         console.error(err);
-
-        return res.status(StatusCodes.UNAUTHORIZED).json({
-            "message": "로그인 세션이 만료되었습니다."
-        });
+        return err;
     }
 }
 


### PR DESCRIPTION
## 배경
- like API 외에도 cart API에 jwt를 사용해야 하는 부분이 있었다.

## 주요 구현 사항
- cart API 중 전체 조회 API와 추가하는 API에 jwt를 사용하여 db에 접근할 수 있도록 하였다.
- 토큰의 기간이 만료되거나, 잘못된 토큰이 들어올 시 try-catch 구문으로 잡아 그에 따른 메세지를 반환할 수 있도록 구현했다.
    - jwt 라이브러리가 제공하는 error 메소드 중 `TokenExpiredError`와 `JsonWebTokenError`를 추가로 이용해 더 자세하게 분류했다.
- 중복되는 if 로직을 `decodedJWT` 함수에 넣어 좀 더 코드를 깔끔하게 구현했다.