### PR TITLE
[Feat] db config env 파일에 옮기고 gitignore에서 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules/
 .env
 
 ### db
-db/
 data.sql

--- a/db/mariadb.js
+++ b/db/mariadb.js
@@ -1,0 +1,9 @@
+const mysql = require("mysql2");
+const dotenv = require("dotenv");
+
+dotenv.config();
+
+const dbConfig = JSON.parse(process.env.DB_CONFIG);
+const connection = mysql.createPool(dbConfig);
+
+module.exports = connection.promise();


### PR DESCRIPTION
## 배경
처음에는 db 커넥팅하는 모듈 자체를 깃헙에 올리지 않았다가, db에서 민감한 부분만 env 파일로 옮기고 나머지 부분만 깃헙에 올리는 방향으로 수정하기로 했다.

## 주요 수정 내용
- `mysql.createPool()`에 하드코딩 되어 있던 db 설정을 env 파일에 JSON 으로 넣어놓고, 해당 설정을 파싱해서 넣어주는 방식으로 수정

## 수정 후
- 민감 정보는 가리고 DB 커넥팅하는 부분을 깃헙에 올릴 수 있어서 더 나은 것 같다.