### PR TITLE
[Feat] jwt 토큰이 있을 때와 없을 때 도서 개별 조회 로직 수정

### DIFF
--- a/controller/bookController.js
+++ b/controller/bookController.js
@@ -1,5 +1,6 @@
 const conn = require("../db");
 const { StatusCodes } = require("http-status-codes");
+const { decodedJWT } = require("../helper");
 
 const allReadBooks = async (req, res) => {
     const { category_id, recent, limit, currentPage } = req.query;
@@ -21,34 +22,53 @@ const allReadBooks = async (req, res) => {
     sql += " LIMIT ? OFFSET ?";
     values = [...values, parseInt(limit), parseInt(offset)];
 
-    let [results, fields] = await conn.query(sql, values);
+    try {
+        let [results, fields] = await conn.query(sql, values);
 
-    if (results[0]) {
-        return res.status(StatusCodes.OK).json(results);
-    } else {
-        return res.status(StatusCodes.NOT_FOUND).json({
-            massage: "존재하지 않는 도서입니다."
-        });
+        if (results.length) {
+            return res.status(StatusCodes.OK).json(results);
+        } else {
+            return res.status(StatusCodes.NOT_FOUND).json([]);
+        }
+    } catch (error) {
+        console.error("Error reading book detail:", error);
+
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
     }
 }
 
+
 const detailReadBook = async (req, res) => {
     const { id } = req.params;
-    const { user_id } = req.body;
+    const authorization = decodedJWT(req, res);
 
+    let sql = "";
+    let value = [];
     let likeSql = "SELECT count(*) FROM LIKES_TB WHERE liked_book_id = BOOKS_TB.id";
     let isLikeSql = "SELECT EXISTS (SELECT * FROM LIKES_TB WHERE user_id = ? AND liked_book_id = ?)";
 
-    let sql = `SELECT *, (${likeSql}) AS likes, (${isLikeSql}) AS isLiked FROM BOOKS_TB LEFT JOIN CATEGORIES_TB ON BOOKS_TB.category_id = CATEGORIES_TB.category_id WHERE BOOKS_TB.id = ?`;
-
-    let [results, fields] = await conn.query(sql, [parseInt(user_id), parseInt(id), parseInt(id)]);
-
-    if (results[0]) {
-        return res.status(StatusCodes.OK).json(results);
+    if (!authorization) {
+        sql = `SELECT *, (${likeSql}) AS likes FROM BOOKS_TB LEFT JOIN CATEGORIES_TB ON BOOKS_TB.category_id = CATEGORIES_TB.category_id WHERE BOOKS_TB.id = ?`;
+        value = [parseInt(id), parseInt(id)];
     } else {
-        return res.status(StatusCodes.NOT_FOUND).json({
-            massage: "존재하지 않는 도서입니다."
-        });
+        sql = `SELECT *, (${likeSql}) AS likes, (${isLikeSql}) AS isLiked FROM BOOKS_TB LEFT JOIN CATEGORIES_TB ON BOOKS_TB.category_id = CATEGORIES_TB.category_id WHERE BOOKS_TB.id = ?`;
+        value = [authorization.id, parseInt(id), parseInt(id)];
+    }
+
+    try {
+        let [results, fields] = await conn.query(sql, value);
+
+        if (results.length) {
+            return res.status(StatusCodes.OK).json(results);
+        } else {
+            return res.status(StatusCodes.NOT_FOUND).json({
+                massage: "존재하지 않는 도서입니다."
+            });
+        }
+    } catch (error) {
+        console.error("Error reading book detail:", error);
+
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end();
     }
 }
 

--- a/helper/index.js
+++ b/helper/index.js
@@ -8,7 +8,12 @@ dotenv.config();
 const decodedJWT = (req, res) => {
     try {
         let receivedJWT = req.headers["authorization"]
-        return jwt.verify(receivedJWT, process.env.PRIVATE_KEY);
+
+        if (receivedJWT) {
+            return jwt.verify(receivedJWT, process.env.PRIVATE_KEY);
+        } else {
+            return receivedJWT;
+        }
     } catch (err) {
         console.error(err);
 


### PR DESCRIPTION
## 배경
- jwt 토큰이  있을 때 (로그인 한 경우)와 jwt 토큰이 없을 때 (로그인을 하지 않은 경우) 를 나누어 도서 개별 조회 시 좋아요를 클릭했는지 안 했는지 나누어 조회할 수 있도록 로직을 수정해야 했다.

## 주요 변경 사항
- `decodedJWT` 함수의 try 구문 안을 jwt 토큰이 있을 때는 jwt를 복호화하도록 했고, 없을 때는 empty string이 들어오기 때문에 그냥 jwt가 들어온 그대로 return 하도록 수정했다.
- authorization 헤더를 통해 빈 값이 들어오면 `liked` (좋아요 했는지 안 했는지 판단하는 부분) 부분을 조회하지 않도록 했고, 값이 들어오면 로그인이 된 상태라고 판단해 `liked` 부분을 조회하도록 수정했다.
- `allReadBooks` 핸들러와 `detailReadBook` 핸들러도 try-catch 구문으로 감싸 서버 에러가 발생시 꺼지지 않고 에러 메세지를 보여줄 수 있도록 수정했다.