### PR TITLE
[Feat] pagination 추가 및 response body 양식 수정

### DIFF
--- a/controller/bookController.js
+++ b/controller/bookController.js
@@ -3,19 +3,19 @@ const { StatusCodes } = require("http-status-codes");
 const { decodedJWT } = require("../helper");
 
 const allReadBooks = async (req, res) => {
-    const { category_id, recent, limit, currentPage } = req.query;
+    const { categoryId, recent, limit, currentPage } = req.query;
     let offset = (parseInt(currentPage) - 1) * parseInt(limit);
     let values = [];
     let likeSql = "SELECT count(*) FROM LIKES_TB WHERE liked_book_id = BOOKS_TB.id";
     let sql = `SELECT SQL_CALC_FOUND_ROWS *, (${likeSql}) AS likes FROM BOOKS_TB`;
     let countSql = "SELECT found_rows() AS counts";
 
-    if (category_id && recent) {
+    if (categoryId && recent) {
         sql += " WHERE category_id = ? AND pub_date BETWEEN DATE_SUB(NOW(), INTERVAL 1 MONTH) AND NOW()";
-        values = [parseInt(category_id)];
-    } else if (category_id) {
+        values = [parseInt(categoryId)];
+    } else if (categoryId) {
         sql += " WHERE category_id = ?";
-        values = [parseInt(category_id)];
+        values = [parseInt(categoryId)];
     } else if (recent) {
         sql += " WHERE pub_date BETWEEN DATE_SUB(NOW(), INTERVAL 1 MONTH) AND NOW()";
     }
@@ -32,9 +32,26 @@ const allReadBooks = async (req, res) => {
             currentPage: currentPage
         }
 
+        const formattedResults = results.map(result => ({
+            id: result.id,
+            categoryId: result.category_id,
+            title: result.title,
+            img: result.img,
+            form: result.form,
+            isbn: result.isbn,
+            summary: result.summary,
+            detail: result.detail,
+            author: result.author,
+            contents: result.contents,
+            pages: result.pages,
+            price: result.price,
+            likes: result.likes,
+            pubDate: result.pub_date
+        }));
+
         if (results !== undefined && results !== null && results.length > 0) {
             return res.status(StatusCodes.OK).json({
-                books: results,
+                books: formattedResults,
                 pagination
             });
         } else {
@@ -71,8 +88,26 @@ const detailReadBook = async (req, res) => {
     try {
         let [results, fields] = await conn.query(sql, value);
 
+        const formattedResults = results.map(result => ({
+            id: result.id,
+            categoryId: result.category_id,
+            title: result.title,
+            img: result.img,
+            form: result.form,
+            isbn: result.isbn,
+            summary: result.summary,
+            detail: result.detail,
+            author: result.author,
+            contents: result.contents,
+            pages: result.pages,
+            price: result.price,
+            likes: result.likes,
+            isLiked: result.isLiked,
+            pubDate: result.pub_date
+        }));
+
         if (results.length) {
-            return res.status(StatusCodes.OK).json(results);
+            return res.status(StatusCodes.OK).json(formattedResults);
         } else {
             return res.status(StatusCodes.NOT_FOUND).json({
                 massage: "존재하지 않는 도서입니다."

--- a/controller/cartController.js
+++ b/controller/cartController.js
@@ -18,8 +18,17 @@ const allReadCartItems = async (req, res) => {
     try {
         let [results, fields] = await conn.query(sql, [decoded.id, selected]);
 
+        const formattedResults = results.map(result => ({
+            id: result.id,
+            bookId: result.book_id,
+            title: result.title,
+            summary: result.summary,
+            amount: result.amount,
+            price: result.price
+        }));
+
         return (results !== undefined && results !== null && results.length > 0) ?
-            res.status(StatusCodes.OK).json(results) :
+            res.status(StatusCodes.OK).json(formattedResults) :
             res.status(StatusCodes.OK).json([]);
     } catch (error) {
         console.error("Error reading cart lists:", error);
@@ -29,13 +38,13 @@ const allReadCartItems = async (req, res) => {
 }
 
 const addToCarts = async (req, res) => {
-    const { book_id, amount } = req.body;
+    const { bookId, amount } = req.body;
     const decoded = decodedJWT(req, res);
 
     let sql = "INSERT INTO CART_ITEMS_TB (book_id, amount, user_id) VALUES (?, ?, ?)";
 
     try {
-        let [results, fields] = await conn.query(sql, [parseInt(book_id), parseInt(amount), decoded.id]);
+        let [results, fields] = await conn.query(sql, [parseInt(bookId), parseInt(amount), decoded.id]);
 
         if (results.affectedRows === 0) {
             return res.status(StatusCodes.BAD_REQUEST).end();

--- a/controller/categoryController.js
+++ b/controller/categoryController.js
@@ -7,8 +7,13 @@ const allReadCategory = async (req, res) => {
     try {
         let [results, fields] = await conn.query(sql);
 
+        const formattedResults = results.map(result => ({
+            categoryId: result.category_id,
+            genre: result.genre
+        }));
+
         if (results.length) {
-            return res.status(StatusCodes.OK).json(results);
+            return res.status(StatusCodes.OK).json(formattedResults);
         } else {
             return res.status(StatusCodes.NOT_FOUND).end();
         }

--- a/controller/orderController.js
+++ b/controller/orderController.js
@@ -13,8 +13,19 @@ const readAllOrder = async (req, res) => {
     try {
         let [results, fields] = await conn.query(sql, [authorization.id]);
 
+        const formattedResults = results.map(result => ({
+            id: result.id,
+            bookTitle: result.book_title,
+            totalAmount: result.total_amount,
+            totalPrice: result.total_price,
+            receiver: result.receiver,
+            contact: result.contact,
+            address: result.address,
+            createdAt: result.created_at
+        }));
+
         return (results !== undefined && results !== null && results.length > 0) ?
-            res.status(StatusCodes.OK).json(results) :
+            res.status(StatusCodes.OK).json(formattedResults) :
             res.status(StatusCodes.OK).json([]);
     } catch (error) {
         console.error("Error reading orders:", error);
@@ -24,7 +35,7 @@ const readAllOrder = async (req, res) => {
 }
 
 const addToOrder = async (req, res) => {
-    const { items, delivery, total_amount, total_price, first_book_title } = req.body;
+    const { items, delivery, totalAmount, totalPrice, firstBookTitle } = req.body;
     const authorization = decodedJWT(req, res);
 
     // CART_ITEMS_TB SELECT id 조건절
@@ -36,7 +47,7 @@ const addToOrder = async (req, res) => {
 
     // ORDERS_TB INSERT (ORDERS_TB id 있어야 함)
     let ordersSql = `INSERT INTO ORDERS_TB (book_title, total_amount, total_price, user_id, delivery_id) VALUES (?, ?, ?, ?, ?)`;
-    let ordersValues = [first_book_title, total_amount, total_price, authorization.id];
+    let ordersValues = [firstBookTitle, totalAmount, totalPrice, authorization.id];
 
     // ORDERED_BOOKS_TB INSERT (가장 마지막에 되어야 함)
     let orderedBooksSql = `INSERT INTO ORDERED_BOOKS_TB (order_id, book_id, amount) VALUES ?`;
@@ -89,8 +100,16 @@ const readDetailOrder = async (req, res) => {
     try {
         const [results, fields] = await conn.query(sql, [parseInt(id)]);
 
+        const formattedResults = results.map(result => ({
+            bookId: result.book_id,
+            title: result.title,
+            author: result.author,
+            price: result.price,
+            amount: result.amount,
+        }));
+
         return (results !== undefined && results !== null && results.length > 0) ?
-            res.status(StatusCodes.OK).json(results) :
+            res.status(StatusCodes.OK).json(formattedResults) :
             res.status(StatusCodes.OK).json([]);
     } catch (error) {
         console.error("Error reading orders detail:", error);


### PR DESCRIPTION
## 배경
- 현재 클라이언트 단에서 pagination 관련한 정보를 어떻게 저장하는지 모르기 때문에 서버 쪽에서 response body에 전체 권 수와 현재 페이지를 보내주도록 수정해줘야 한다.
- response body 양식도 snake case가 아니라 camel case 이므로 이 부분도 수정해줘야 한다.


## 주요 수정 사항
- 전체 도서 조회 API에서 기존에 limit와 offset에 맞춰 배열에 item만 담아서 보내는 형태였다면, 배열과 함께 pagination 객체를 json에 같이 추가해 전체 권수와 현재 페이지를 같이 담아 보내주도록 수정했다.
-  response body 양식을 camel case로 수정했다.
   - 순서가 달라지지 않도록 map 메소드를 이용해 돌릴 때 순서를 하나씩 다 대치해주었다. 